### PR TITLE
Two column responsive section

### DIFF
--- a/src/src/Mvc/Kentico/Xperience/Xperience/ComponentIdentifier.cs
+++ b/src/src/Mvc/Kentico/Xperience/Xperience/ComponentIdentifier.cs
@@ -13,6 +13,8 @@ namespace BlogTemplate.Mvc.Kentico.Xperience
 
         public const string GenericColumnSection = Prefix + nameof( GenericColumnSection );
 
+        public const string ResponsiveColumnSection = Prefix + nameof( ResponsiveColumnSection );
+
     }
 
 }

--- a/src/src/Mvc/Kentico/Xperience/Xperience/Models/Sections/ResponsiveColumnSectionProperties.cs
+++ b/src/src/Mvc/Kentico/Xperience/Xperience/Models/Sections/ResponsiveColumnSectionProperties.cs
@@ -1,0 +1,16 @@
+using Kentico.Forms.Web.Mvc;
+using Kentico.PageBuilder.Web.Mvc;
+
+namespace BlogTemplate.Mvc.Kentico.Xperience.Models.Sections
+{
+    public class ResponsiveColumnSectionProperties : ISectionProperties
+    {
+        private const string Tooltip = "Keep the sum of the two columns less than or equal to 100%";
+
+        [EditingComponent( IntInputComponent.IDENTIFIER, Order = 0, Label = "Left Column Width (Percent)", Tooltip = Tooltip )]
+        public int LeftColumnWidth { get; set; } = 60;
+
+        [EditingComponent( IntInputComponent.IDENTIFIER, Order = 0, Label = "Right Column Width (Percent)", Tooltip = Tooltip )]
+        public int RightColumnWidth { get; set; } = 40;
+    }
+}

--- a/src/src/Mvc/Kentico/Xperience/Xperience/RegisterComponents.cs
+++ b/src/src/Mvc/Kentico/Xperience/Xperience/RegisterComponents.cs
@@ -14,3 +14,4 @@ using Kentico.PageBuilder.Web.Mvc;
 [assembly: RegisterWidget( ComponentIdentifier.TextWidget, typeof( TextWidgetViewComponent ), "Text", typeof( TextWidgetProperties ), IconClass = "icon-l-text" )]
 [assembly: RegisterSection( ComponentIdentifier.TwoColumnSection, "Two Columns", customViewName: "~/Views/Shared/Sections/_TwoColumnSection.cshtml", IconClass = "icon-l-cols-2" )]
 [assembly: RegisterSection( ComponentIdentifier.GenericColumnSection, "Generic Column Section", typeof( GenericColumnSectionProperties ), customViewName: "~/Views/Shared/Sections/_GenericColumnSection.cshtml", IconClass = "icon-l-cols-3" )]
+[assembly: RegisterSection( ComponentIdentifier.ResponsiveColumnSection, "Responsive Column Section", typeof( ResponsiveColumnSectionProperties ), customViewName: "~/Views/Shared/Sections/_ResponsiveColumnSection.cshtml", IconClass = "icon-l-cols-70-30" )]

--- a/src/src/Mvc/Kentico/Xperience/Xperience/Views/Shared/Sections/_ResponsiveColumnSection.cshtml
+++ b/src/src/Mvc/Kentico/Xperience/Xperience/Views/Shared/Sections/_ResponsiveColumnSection.cshtml
@@ -1,0 +1,16 @@
+@model ComponentViewModel<ResponsiveColumnSectionProperties>
+
+@{ 
+    var leftPercent = $"{Model.Properties.LeftColumnWidth}%";
+    var rightPercent = $"{Model.Properties.RightColumnWidth}%";
+}
+
+<div class="responsive-column-section">
+    <div class="responsive-col" style="flex-basis:@leftPercent;">
+        <widget-zone />
+    </div>
+
+    <div class="responsive-col" style="flex-basis: @rightPercent;">
+        <widget-zone />
+    </div>
+</div>

--- a/src/src/Mvc/Kentico/Xperience/Xperience/client-ui/rollup.config.js
+++ b/src/src/Mvc/Kentico/Xperience/Xperience/client-ui/rollup.config.js
@@ -64,5 +64,6 @@ const configureInlineEditor = (
     })
   export default [
     configureInlineEditor('text-editor'),
-    configureSection('generic-column')
+    configureSection('generic-column'),
+    configureSection('responsive-column')
   ]

--- a/src/src/Mvc/Kentico/Xperience/Xperience/client-ui/src/sections/responsive-column.js
+++ b/src/src/Mvc/Kentico/Xperience/Xperience/client-ui/src/sections/responsive-column.js
@@ -1,0 +1,1 @@
+import "./responsive-column.scss"

--- a/src/src/Mvc/Kentico/Xperience/Xperience/client-ui/src/sections/responsive-column.scss
+++ b/src/src/Mvc/Kentico/Xperience/Xperience/client-ui/src/sections/responsive-column.scss
@@ -1,0 +1,32 @@
+.responsive-column-section {
+  display: flex;
+  justify-content: space-between;
+
+  .responsive-col-20 {
+    flex-basis: 20%;
+  }
+
+  .responsive-col-30 {
+    flex-basis: 30%;
+  }
+
+  .responsive-col-40 {
+    flex-basis: 40%;
+  }
+
+  .responsive-col-50 {
+    flex-basis: 50%;
+  }
+
+  .responsive-col-60 {
+    flex-basis: 60%;
+  }
+
+  .responsive-col-70 {
+    flex-basis: 70%;
+  }
+
+  .responsive-col-80 {
+    flex-basis: 80%;
+  }
+}


### PR DESCRIPTION
Allows the user to type percentages for the two column widths.
Examples: 
60 / 40
65 / 30 (would have a gutter between the columns)
80 / 20